### PR TITLE
chai v 4.3.1 (pull in CVE-2020-7751)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/PelionIoT/pelion-edge-ready-test-suite#readme",
   "dependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.1",
     "colors": "^1.4.0",
     "commander": "^6.0.0",
     "compare-versions": "^3.6.0",


### PR DESCRIPTION
Update package.json to pull in newer version of chai.