### PR TITLE
Add gitattributes, update chai in vendor-licenses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Normalize line endings for all text-based files
+# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto
+
+# For the following file types, normalize line endings to LF
+.*      text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.jade  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.less  text eol=lf
+*.scss  text eol=lf
+*.md    text eol=lf
+*.sh    text eol=lf
+*.txt   text eol=lf
+*.xml   text eol=lf

--- a/vendor-licenses.txt
+++ b/vendor-licenses.txt
@@ -946,7 +946,7 @@ END OF TERMS AND CONDITIONS
 
 The following NPM packages may be included in this product:
 
- - chai@4.2.0
+ - chai@4.3.1
 
 These packages each contain the following license and notice below:
 


### PR DESCRIPTION
Add `.gitattributes` so that we can skip (hopefully) future line-ending issues.
Update chai version in vendor licenses.txt as well.

