### PR TITLE
Update SW versions for Edge 2.6 / LmPv85

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
 # Pelion Edge ready test suite
 
-For documentation about the Pelion Edge ready test suite, please see the [Pelion Edge documentation](https://developer.pelion.com/docs/device-management-edge/latest/testing/pelion-edge-ready-test-suite.html).
+For a more thorough documentation about the Pelion Edge ready test suite, please see the [Pelion Edge documentation](https://developer.pelion.com/docs/device-management-edge/latest/testing/pelion-edge-ready-test-suite.html).
+
+# Quick start
+
+Run these commands in the shell of the device under test.
+
+```
+curl -LSs https://github.com/PelionIoT/pelion-edge-ready-test-suite/archive/refs/tags/v2.6.0.tar.gz -o perts.tar.gz
+tar -xvzf perts.tar.gz
+wget https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.gz
+tar -xzf node-v16.14.2-linux-arm64.tar.gz
+PATH=$PATH:$HOME/node-v16.14.2-linux-arm64/bin/
+wget https://registry.npmjs.org/npm/-/npm-8.7.0.tgz
+tar -xzf npm-8.7.0.tgz
+cd package
+sudo node bin/npm-cli.js install --prefix /usr/local -gf ../npm-8.7.0.tgz
+cd ../pelion-edge-ready-test-suite-2.6.0
+sudo ./scripts/install_kubectl.sh <K8 API URL> <access key>
+```
+
+K8S API are region based according to following table.
+
+| Region | K8 API URL  |
+|--------|-------------|
+| EU     | `https://edge-k8s.eu-west-1.mbedcloud.com` |
+| US     | `https://edge-k8s.us-east-1.mbedcloud.com` |
+
+There are basic example configurations under `test-configs`, pick the closest match from there based on region (EU/US) and device model. Copy it to this folder and modify it to have your:
+
+- account ID
+- endpoint name
+- access key
+
+details filled in. Example below:
+
+
+```
+cp test-configs/us/rpi3-config.json ./my-config.json
+nano my-config.json
+```
+
+Run the tests `sudo node index.js -c my-config.json -e`.
+- If you exit the shell, you will need to add the PATH again as it is not persisted.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ nano my-config.json
 
 Run the tests `sudo node index.js -c my-config.json -e`.
 - If you exit the shell, you will need to add the PATH again as it is not persisted.
+
+**NOTE! KaaS tests require that the account has Edge KaaS features enabled. By default KaaS features are not enabled.**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ tar -xzf npm-8.7.0.tgz
 cd package
 sudo node bin/npm-cli.js install --prefix /usr/local -gf ../npm-8.7.0.tgz
 cd ../pelion-edge-ready-test-suite-2.6.0
+npm install
 sudo ./scripts/install_kubectl.sh <K8 API URL> <access key>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelion-edge-ready-test-suite",
-  "version": "2.2.0",
+  "version": "2.6.0",
   "description": "Pelion Edge Ready Test Suite",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "compare-versions": "^3.6.0",
     "jsonminify": "^0.4.1",
     "kubernetes-client": "^9.0.0",
-    "mocha": "^8.3.0",
+    "mocha": "^9.2.2",
     "randomstring": "^1.1.5",
     "request": "^2.88.2",
     "stream-buffers": "^3.0.2"
@@ -38,7 +38,7 @@
     "husky": "^5.1.3",
     "junit-report-builder": "^2.1.0",
     "lint-staged": "^10.5.4",
-    "mochawesome": "^6.1.1",
+    "mochawesome": "^7.1.3",
     "prettier-standard": "^9.1.1"
   }
 }

--- a/scripts/install_kubectl.sh
+++ b/scripts/install_kubectl.sh
@@ -23,8 +23,28 @@ set -e
 if [ $# -ne 2 ];
 then
     echo "ERROR - incorrect number of arguments. Usage:"
-    echo " ./install_kubectl.sh <api_url> <api_key>"
+    echo " ./install_kubectl.sh <K8 API URL> <api_key>"
     exit 2
+fi
+
+# Check edge-k8s API variable
+if [ ${#1} -le 30 ];
+then
+    echo "ERROR - K8S API URL $1 seems to be too short"
+    exit 2
+fi
+
+# https://edge-k8s.
+# 1234567890123456
+KUBE=$(expr substr $1 9 9)
+
+if [ "$KUBE" == "edge-k8s." ];
+then
+  # Do nothing, else branch is thing here
+  echo "Download and install kubectl..."
+else
+  echo "ERROR - K8 API URL '$1' is not starting with 'edge-k8s.' as expected."
+  exit 2
 fi
 
 # Install kubectl

--- a/scripts/install_kubectl.sh
+++ b/scripts/install_kubectl.sh
@@ -17,6 +17,15 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+# Stop on errors
+set -e
+
+if [ $# -ne 2 ];
+then
+    echo "ERROR - incorrect number of arguments. Usage:"
+    echo " ./install_kubectl.sh <api_url> <api_key>"
+    exit 2
+fi
 
 # Install kubectl
 curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/arm/kubectl"
@@ -25,7 +34,13 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 kubectl version --client
 
 # Setup kube config
-mkdir ~/.kube
+if [ -d "$HOME"/.kube ];
+then
+    echo "$HOME"/.kube folder alredy exists, removing it.
+    rm -rf "$HOME"/.kube
+fi
+
+mkdir "$HOME"/.kube
 echo "apiVersion: v1
 clusters:
 - cluster:
@@ -42,7 +57,4 @@ preferences: {}
 users:
 - name: edge-k8s
   user:
-    token: $2" >> ~/.kube/config
-
-# How to run
-# ./install_kubectl.sh <api_url> <api_key>
+    token: $2" >> "$HOME"/.kube/config

--- a/test-cases/l1_file_system_and_specification_tests/partition.js
+++ b/test-cases/l1_file_system_and_specification_tests/partition.js
@@ -45,17 +45,18 @@ describe('[Level 1] PartitionTests', () => {
   })
   describe('#PartitionSize', () => {
     Object.keys(global.config.partitions).forEach(partition_name => {
-      it(`Should return true if ${partition_name} partition mounted`, done => {
+      it(`Should return true if ${partition_name} is large enough`, done => {
         exec(
-          `df -h | grep ${partition_name} | awk '{print $2}'`,
+          `df | grep ${partition_name} | awk '{print $2}'`,
           (error, stdout) => {
+            console.log(stdout)
             if (error) {
               done(error)
             } else {
               assert.operator(
-                parseFloat(stdout.trim()),
+                parseInt(stdout.trim()),
                 '>=',
-                parseFloat(global.config.partitions[partition_name].size),
+                parseInt(global.config.partitions[partition_name].size),
                 `Expected: ${partition_name} size not valid`
               )
               done()

--- a/test-cases/l1_file_system_and_specification_tests/specifications.js
+++ b/test-cases/l1_file_system_and_specification_tests/specifications.js
@@ -157,7 +157,6 @@ describe('[Level 1] SpecificationTests', () => {
     var identityJSONkeys = [
       'ledConfig',
       'radioConfig',
-      'hardwareVersion',
       'gatewayServicesAddress'
     ]
     identityJSONkeys.forEach(identity_key => {

--- a/test-cases/l4_smoke_tests/edge_smoke.js
+++ b/test-cases/l4_smoke_tests/edge_smoke.js
@@ -31,6 +31,10 @@ describe('[Level 4] EdgeCoreTests', () => {
           } else {
             var edge_core_info = JSON.parse(body)
             var accountID = global.config.accountID
+            if (accountID === "") {
+              console.log("Account ID is empty, please update your config with account information.")
+              console.log("Account ID given by Edge core is %s.", edge_core_info['account-id'])
+            }
             assert.equal(
               edge_core_info['status'],
               'connected',
@@ -39,7 +43,7 @@ describe('[Level 4] EdgeCoreTests', () => {
             assert.equal(
               edge_core_info['account-id'],
               accountID,
-              `Edge core is not conncted with right accountID`
+              `Edge core is not connected with right accountID`
             )
             done()
           }

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "14G"
+            "size": "14000000"
         },
         "/dev/mmcblk1p1": {
             "name": "Boot",
-            "size": "26M"
+            "size": "22000"
         },
         "devtmpfs": {
             "name": "Dev",
-            "size": "457M"
+            "size": "450000"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Avnet_XCZU3EG-SFVA625_SoM",
         "apiAddress":"https://api.eu-west-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.eu-west-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.eu-west-1.mbedcloud.com"
@@ -57,7 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
         "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
@@ -68,7 +66,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.15.16-lmp-standard",

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.4.105-lmp-standard",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.15.16-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -56,7 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -67,7 +67,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.15.16-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/eu/avnet-config.json
+++ b/test-configs/eu/avnet-config.json
@@ -69,7 +69,7 @@
         "openssl": "1.1.1",
         "node": "16.14.2",
         "edge_core": "0.19.1",
-        "kernel": "5.15.16-lmp-standard",
+        "kernel": "5.10.93-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {
@@ -109,7 +109,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.4.105-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.93-lmp-standard/kernel/drivers",
     "drivers": [
         "bcma",
         "block",

--- a/test-configs/eu/imx8-config.json
+++ b/test-configs/eu/imx8-config.json
@@ -66,7 +66,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/eu/imx8-config.json
+++ b/test-configs/eu/imx8-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "2.4G"
+            "size": "2200000"
         },
         "/dev/mmcblk1p1": {
             "name": "Boot",
-            "size": "84M"
+            "size": "80000"
         },
         "devtmpfs": {
             "name": "Dev",
-            "size": "457M"
+            "size": "450000"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/imx8-config.json
+++ b/test-configs/eu/imx8-config.json
@@ -66,11 +66,11 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",
         "td-agent-bit": "1.3.5"
     },

--- a/test-configs/eu/imx8-config.json
+++ b/test-configs/eu/imx8-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "SolidRun_i.MX8MM_HummingBoard_Pulse",
         "apiAddress":"https://api.eu-west-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.eu-west-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.eu-west-1.mbedcloud.com"
@@ -56,9 +55,7 @@
         "lwm2m.eu-west-1.mbedcloud.com"
     ],
     "config_path": {
-        "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
+        "identityJSON": "/userdata/edge_gw_config/identity.json",0
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {
@@ -68,7 +65,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",

--- a/test-configs/eu/imx8-config.json
+++ b/test-configs/eu/imx8-config.json
@@ -55,7 +55,7 @@
         "lwm2m.eu-west-1.mbedcloud.com"
     ],
     "config_path": {
-        "identityJSON": "/userdata/edge_gw_config/identity.json",0
+        "identityJSON": "/userdata/edge_gw_config/identity.json",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.10.17-lmp-standard",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {
@@ -111,7 +111,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.10.17-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.31-lmp-standard/kernel/drivers",
     "drivers": [
         "block",
         "bluetooth",

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -32,7 +32,7 @@
         "max_cpu_freq": 4200000,
         "device_mem": {
             "MemTotal": 900000,
-            "MemFree": 30000,
+            "MemFree": 28000,
             "MemAvailable": 400000
         },
         "entropy":200,

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -56,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Raspberry_Pi_3_Model_B_Plus_Rev_1.3",
         "apiAddress":"https://api.eu-west-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.eu-west-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.eu-west-1.mbedcloud.com"
@@ -68,7 +67,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
@@ -84,8 +83,8 @@
             "size": "42M"
         },
         "devtmpfs": {
-            "name": "Dev",
-            "size": "325M"
+            "name": "devtmpfs",
+            "size": "321M"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -68,7 +68,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/eu/rpi3-config.json
+++ b/test-configs/eu/rpi3-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.6G"
+            "size": "1400000"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
-            "size": "42M"
+            "size": "40000"
         },
         "devtmpfs": {
             "name": "devtmpfs",
-            "size": "321M"
+            "size": "300000"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/rpi4-config.json
+++ b/test-configs/eu/rpi4-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.10.17-lmp-standard",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {
@@ -111,7 +111,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.10.17-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.31-lmp-standard/kernel/drivers",
     "drivers": [
         "block",
         "bluetooth",

--- a/test-configs/eu/rpi4-config.json
+++ b/test-configs/eu/rpi4-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.5G"
+            "size": "1400000"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
-            "size": "42M"
+            "size": "40000"
         },
         "devtmpfs": {
             "name": "devtmpfs",
-            "size": "791M"
+            "size": "790000"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/rpi4-config.json
+++ b/test-configs/eu/rpi4-config.json
@@ -66,7 +66,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/eu/rpi4-config.json
+++ b/test-configs/eu/rpi4-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Raspberry_Pi_4_Model_B_Rev_1.1",
         "apiAddress":"https://api.eu-west-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.eu-west-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.eu-west-1.mbedcloud.com"
@@ -57,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {
@@ -68,7 +65,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
@@ -77,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.6G"
+            "size": "1.5G"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
             "size": "42M"
         },
         "devtmpfs": {
-            "name": "Dev",
-            "size": "325M"
+            "name": "devtmpfs",
+            "size": "791M"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/snap-config.json
+++ b/test-configs/eu/snap-config.json
@@ -79,23 +79,23 @@
     "partitions": {
         "/dev/loop6": {
             "name": "snap_pelion-edge_x1",
-            "size": "2.4G"
+            "size": "2576980378"
         },
         "/dev/loop10": {
             "name": "snap-network-manager",
-            "size": "4.3M"
+            "size": "4508877"
         },
         "/dev/loop3": {
             "name": "snap-modem-manager",
-            "size": "1.8M"
+            "size": "1887437"
         },
         "/dev/loop12": {
             "name": "snap-snap-store",
-            "size": "50M"
+            "size": "52428800"
         },
         "udev": {
             "name": "Dev",
-            "size": "2.4G"
+            "size": "2576980378"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/snap-config.json
+++ b/test-configs/eu/snap-config.json
@@ -79,23 +79,23 @@
     "partitions": {
         "/dev/loop6": {
             "name": "snap_pelion-edge_x1",
-            "size": "2576980378"
+            "size": "2400000"
         },
         "/dev/loop10": {
             "name": "snap-network-manager",
-            "size": "4508877"
+            "size": "4300"
         },
         "/dev/loop3": {
             "name": "snap-modem-manager",
-            "size": "1887437"
+            "size": "1800"
         },
         "/dev/loop12": {
             "name": "snap-snap-store",
-            "size": "52428800"
+            "size": "50000"
         },
         "udev": {
             "name": "Dev",
-            "size": "2576980378"
+            "size": "2400000"
         }
     },
     "fileSystem": [

--- a/test-configs/eu/snap-config.json
+++ b/test-configs/eu/snap-config.json
@@ -40,7 +40,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "rpi3bplus",
         "apiAddress":"https://api.eu-west-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.eu-west-1.mbedcloud.com"
     },

--- a/test-configs/us/avnet-config.json
+++ b/test-configs/us/avnet-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Avnet_XCZU3EG-SFVA625_SoM",
         "apiAddress":"https://api.us-east-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.us-east-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.us-east-1.mbedcloud.com"
@@ -57,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {
@@ -68,7 +65,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.15.16-lmp-standard",

--- a/test-configs/us/avnet-config.json
+++ b/test-configs/us/avnet-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "14G"
+            "size": "14000000"
         },
         "/dev/mmcblk1p1": {
             "name": "Boot",
-            "size": "26M"
+            "size": "22000"
         },
         "devtmpfs": {
             "name": "Dev",
-            "size": "457M"
+            "size": "450000"
         }
     },
     "fileSystem": [

--- a/test-configs/us/avnet-config.json
+++ b/test-configs/us/avnet-config.json
@@ -68,7 +68,7 @@
         "openssl": "1.1.1",
         "node": "16.14.2",
         "edge_core": "0.19.1",
-        "kernel": "5.15.16-lmp-standard",
+        "kernel": "5.10.93-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {
@@ -108,7 +108,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.4.105-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.93-lmp-standard/kernel/drivers",
     "drivers": [
         "bcma",
         "block",

--- a/test-configs/us/avnet-config.json
+++ b/test-configs/us/avnet-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.4.105-lmp-standard",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.15.16-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {

--- a/test-configs/us/avnet-config.json
+++ b/test-configs/us/avnet-config.json
@@ -66,7 +66,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.15.16-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/us/imx8-config.json
+++ b/test-configs/us/imx8-config.json
@@ -56,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {

--- a/test-configs/us/imx8-config.json
+++ b/test-configs/us/imx8-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "2.4G"
+            "size": "2200000"
         },
         "/dev/mmcblk1p1": {
             "name": "Boot",
-            "size": "84M"
+            "size": "80000"
         },
         "devtmpfs": {
             "name": "Dev",
-            "size": "457M"
+            "size": "450000"
         }
     },
     "fileSystem": [

--- a/test-configs/us/imx8-config.json
+++ b/test-configs/us/imx8-config.json
@@ -66,11 +66,11 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",
         "td-agent-bit": "1.3.5"
     },

--- a/test-configs/us/imx8-config.json
+++ b/test-configs/us/imx8-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "SolidRun_i.MX8MM_HummingBoard_Pulse",
         "apiAddress":"https://api.us-east-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.us-east-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.us-east-1.mbedcloud.com"
@@ -68,7 +67,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",

--- a/test-configs/us/imx8-config.json
+++ b/test-configs/us/imx8-config.json
@@ -68,7 +68,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.4.104-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -32,7 +32,7 @@
         "max_cpu_freq": 4200000,
         "device_mem": {
             "MemTotal": 900000,
-            "MemFree": 30000,
+            "MemFree": 28000,
             "MemAvailable": 400000
         },
         "entropy":200,

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Raspberry_Pi_3_Model_B_Plus_Rev_1.3",
         "apiAddress":"https://api.us-east-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.us-east-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.us-east-1.mbedcloud.com"
@@ -57,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {
@@ -67,8 +64,8 @@
     "program_version": {
         "maestro": "0.1.0",
         "docker": "20.10.10",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1l",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
@@ -84,8 +81,8 @@
             "size": "42M"
         },
         "devtmpfs": {
-            "name": "Dev",
-            "size": "325M"
+            "name": "devtmpfs",
+            "size": "321M"
         }
     },
     "fileSystem": [

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -108,7 +108,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.10.17-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.31-lmp-standard/kernel/drivers",
     "drivers": [
         "block",
         "bluetooth",

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -66,7 +66,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.6G"
+            "size": "1400000"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
-            "size": "42M"
+            "size": "40000"
         },
         "devtmpfs": {
             "name": "devtmpfs",
-            "size": "321M"
+            "size": "300000"
         }
     },
     "fileSystem": [

--- a/test-configs/us/rpi3-config.json
+++ b/test-configs/us/rpi3-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
+        "docker": "20.10.10",
         "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.10.17-lmp-standard",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {

--- a/test-configs/us/rpi4-config.json
+++ b/test-configs/us/rpi4-config.json
@@ -39,7 +39,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "Raspberry_Pi_4_Model_B_Rev_1.1",
         "apiAddress":"https://api.us-east-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.us-east-1.mbedcloud.com",
         "kaasServicesAddress": "https://edge-k8s.us-east-1.mbedcloud.com"
@@ -57,8 +56,6 @@
     ],
     "config_path": {
         "identityJSON": "/userdata/edge_gw_config/identity.json",
-        "relay_term_config": "/wigwag/wigwag-core-modules/relay-term/config/config.json",
-        "device_db_yaml_config": "/wigwag/etc/devicejs/devicedb.yaml",
         "td_agent_bit_conf": "/etc/td-agent-bit/td-agent-bit.conf"
     },
     "binary_path": {
@@ -68,7 +65,7 @@
         "maestro": "0.1.0",
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
-        "openssl": "1.1.1l",
+        "openssl": "1.1.1",
         "node": "16.13.0",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
@@ -77,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.6G"
+            "size": "1.5G"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
             "size": "42M"
         },
         "devtmpfs": {
-            "name": "Dev",
-            "size": "325M"
+            "name": "devtmpfs",
+            "size": "791M"
         }
     },
     "fileSystem": [

--- a/test-configs/us/rpi4-config.json
+++ b/test-configs/us/rpi4-config.json
@@ -66,12 +66,12 @@
     },
     "program_version": {
         "maestro": "0.1.0",
-        "docker": "19.03.13-ce",
-        "openssh": "OpenSSH_8.3p1",
-        "openssl": "1.1.1",
-        "node": "12.19.0",
-        "edge_core": "0.15.0",
-        "kernel": "5.10.17-lmp-standard",
+        "docker": "20.10.10",
+        "openssh": "OpenSSH_8.5p1",
+        "openssl": "1.1.1l",
+        "node": "16.13.0",
+        "edge_core": "0.19.1",
+        "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"
     },
     "partitions": {
@@ -111,7 +111,7 @@
         "var",
         "wigwag"
     ],
-    "drivers_path": "/lib/modules/5.10.17-lmp-standard/kernel/drivers",
+    "drivers_path": "/lib/modules/5.10.31-lmp-standard/kernel/drivers",
     "drivers": [
         "block",
         "bluetooth",

--- a/test-configs/us/rpi4-config.json
+++ b/test-configs/us/rpi4-config.json
@@ -74,15 +74,15 @@
     "partitions": {
         "/dev/disk/by-label/otaroot": {
             "name": "Sysroot",
-            "size": "1.5G"
+            "size": "1400000"
         },
         "/dev/mmcblk0p1": {
             "name": "Boot",
-            "size": "42M"
+            "size": "40000"
         },
         "devtmpfs": {
             "name": "devtmpfs",
-            "size": "791M"
+            "size": "790000"
         }
     },
     "fileSystem": [

--- a/test-configs/us/rpi4-config.json
+++ b/test-configs/us/rpi4-config.json
@@ -66,7 +66,7 @@
         "docker": "20.10.10",
         "openssh": "OpenSSH_8.5p1",
         "openssl": "1.1.1",
-        "node": "16.13.0",
+        "node": "16.14.2",
         "edge_core": "0.19.1",
         "kernel": "5.10.31-lmp-standard",
         "td-agent-bit": "1.3.5"

--- a/test-configs/us/snap-config.json
+++ b/test-configs/us/snap-config.json
@@ -40,7 +40,6 @@
         "SOC_die_temprature": 80,
         "ledConfig": "01",
         "radioConfig": "00",
-        "hardwareVersion": "rpi3bplus",
         "apiAddress":"https://api.us-east-1.mbedcloud.com",
         "gatewayServicesAddress":"https://gateways.us-east-1.mbedcloud.com"
     },

--- a/test-configs/us/snap-config.json
+++ b/test-configs/us/snap-config.json
@@ -79,23 +79,23 @@
     "partitions": {
         "/dev/loop6": {
             "name": "snap_pelion-edge_x1",
-            "size": "2.4G"
+            "size": "2400000"
         },
         "/dev/loop10": {
             "name": "snap-network-manager",
-            "size": "4.3M"
+            "size": "4300"
         },
         "/dev/loop3": {
             "name": "snap-modem-manager",
-            "size": "1.8M"
+            "size": "1800"
         },
         "/dev/loop12": {
             "name": "snap-snap-store",
-            "size": "50M"
+            "size": "50000"
         },
         "udev": {
             "name": "Dev",
-            "size": "2.4G"
+            "size": "2400000"
         }
     },
     "fileSystem": [


### PR DESCRIPTION
* SW version updates, both to 
    * components on the device & 
    * also the node.js & npm and
    * `package.json` (this closes the vulnerability issues w node/npm).
* Sanity checks for `install_kube.sh` script.
* partition size comparisons using `df` instead of `df -h` (kudos to @marcuschangarm for noticing this issue)
* Quick start to README.

Versions have been updated, update configs to match.
- 189/189 pass with RPI3B and RPI4
- Testing needed on i.MX8 and AVNET ZU3EG.

NOTE! The quick instructions advice to download a 2.6.0 release of the PERTS. This is of course **not available yet**. Use for example `git clone https://github.com/PelionIoT/pelion-edge-ready-test-suite.git -b release-2.6`   instead.
