### PR TITLE
Pin colors.js to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@kubernetes/client-node": "^0.14.3",
     "atomic-sleep": "^1.0.0",
     "chai": "^4.3.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^6.0.0",
     "compare-versions": "^3.6.0",
     "jsonminify": "^0.4.1",


### PR DESCRIPTION
This is to avoid the newer versions the colors.js author is doing with
a busy loop causing a sort of DDoS. GitHub gives a dependabot warning
on this:

https://github.com/PelionIoT/pelion-edge-ready-test-suite/security/dependabot/1

colors (npm) >= 1.4.1

The package colors after 1.4.0 are vulnerable to Denial of Service (DoS) that was
introduced through an infinite loop in the americanFlag module.
Unfortunately this appears to have been a purposeful attempt by a maintainer of colors
to make the package unusable, other maintainers' controls over this package appear to
have been revoked in an attempt to prevent them from fixing the issue.

Vulnerable Code js for (let i = 666; i < Infinity; i++;)

Alternative Remediation Suggested * Pin dependancy to 1.4.0