### PR TITLE
jq, KaaS server address from config & Alpine 3.18

### DIFF
--- a/conf/test_pod.yaml
+++ b/conf/test_pod.yaml
@@ -43,7 +43,7 @@ spec:
         - echo 'pod is running'; sleep 6000000
       command:
         - /bin/sh
-      image: alpine:3.9
+      image: alpine:3.18
       imagePullPolicy: IfNotPresent
       name: client
       resources:

--- a/scripts/perts.sh
+++ b/scripts/perts.sh
@@ -42,10 +42,21 @@ usage() {
   echo "  -e                  echo commands (debug), default off"
   echo "  --help              Show this help message and exit"
   echo ""
+  echo "Requires jq to be installed."
+  echo ""
   echo "NOTE! Must be run as sudo, installation steps require sudo rights."
   echo "You must run this script from the $REPONAME -folder."
-  echo "I.e. scripts/$SCRIPTNAME -a <accesskey>"
+  echo "I.e. sudo scripts/$SCRIPTNAME -a <accesskey>"
   exit 1
+}
+
+assertInstalled() {
+  for var in "$@"; do
+      if ! which "$var" &> /dev/null; then
+          echo "Please install $var - for example sudo apt-get install $var!"
+          exit 1
+      fi
+  done
 }
 
 curdir=$(pwd)
@@ -105,6 +116,8 @@ case $(uname -m) in
       exit 1
       ;;
 esac
+
+assertInstalled jq
 
 # Get nodejs
 # wget https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.gz

--- a/test-configs/avnet-config.json
+++ b/test-configs/avnet-config.json
@@ -1,6 +1,6 @@
 {
     "title": "pelion-edge-ready-test-suite",
-    "version":"2.6.0",
+    "version":"2.6.1",
     "device_type": "avnet",
     "tests_directory": "test-cases",
     "accountID": "",

--- a/test-configs/imx8-config.json
+++ b/test-configs/imx8-config.json
@@ -1,6 +1,6 @@
 {
     "title": "pelion-edge-ready-test-suite",
-    "version":"2.6.0",
+    "version":"2.6.1",
     "device_type": "i.MX8",
     "tests_directory": "test-cases",
     "accountID": "",

--- a/test-configs/rpi3-config.json
+++ b/test-configs/rpi3-config.json
@@ -1,6 +1,6 @@
 {
     "title": "pelion-edge-ready-test-suite",
-    "version":"2.6.0",
+    "version":"2.6.1",
     "device_type": "rpi3bplus",
     "tests_directory": "test-cases",
     "accountID": "",

--- a/test-configs/rpi4-config.json
+++ b/test-configs/rpi4-config.json
@@ -1,6 +1,6 @@
 {
     "title": "pelion-edge-ready-test-suite",
-    "version":"2.6.0",
+    "version":"2.6.1",
     "device_type": "rpi4",
     "tests_directory": "test-cases",
     "accountID": "",

--- a/test-configs/snap-config.json
+++ b/test-configs/snap-config.json
@@ -1,6 +1,6 @@
 {
     "title": "pelion-edge-ready-test-suite",
-    "version":"2.6.0",
+    "version":"2.6.1",
     "tests_directory": "test-cases",
     "accountID": "",
     "internal_id": "",

--- a/utils/kaas_utils.js
+++ b/utils/kaas_utils.js
@@ -25,7 +25,7 @@ module.exports.podConfig = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.9'
+  conatinerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',
@@ -55,7 +55,7 @@ module.exports.podWithHostNW = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.9'
+  conatinerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',
@@ -86,7 +86,7 @@ module.exports.podWithFixHostname = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.9'
+  conatinerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',

--- a/utils/kaas_utils.js
+++ b/utils/kaas_utils.js
@@ -25,7 +25,7 @@ module.exports.podConfig = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.18'
+  containerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',
@@ -41,7 +41,7 @@ module.exports.podConfig = (
       containers: [
         {
           name: containername,
-          image: conatinerimage,
+          image: containerimage,
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }
@@ -55,7 +55,7 @@ module.exports.podWithHostNW = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.18'
+  containerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',
@@ -72,7 +72,7 @@ module.exports.podWithHostNW = (
       containers: [
         {
           name: containername,
-          image: conatinerimage,
+          image: containerimage,
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }
@@ -86,7 +86,7 @@ module.exports.podWithFixHostname = (
   nodename,
   label = { app: 'test' },
   containername = 'client',
-  conatinerimage = 'alpine:3.18'
+  containerimage = 'alpine:3.18'
 ) => {
   return {
     apiVersion: 'v1',
@@ -102,7 +102,7 @@ module.exports.podWithFixHostname = (
       containers: [
         {
           name: containername,
-          image: conatinerimage,
+          image: containerimage,
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }

--- a/utils/kaas_utils.js
+++ b/utils/kaas_utils.js
@@ -42,6 +42,12 @@ module.exports.podConfig = (
         {
           name: containername,
           image: containerimage,
+          resources: {
+            limits: {
+              cpu: '200m',
+              memory: '100Mi'
+            }
+          },
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }
@@ -73,6 +79,12 @@ module.exports.podWithHostNW = (
         {
           name: containername,
           image: containerimage,
+          resources: {
+            limits: {
+              cpu: '200m',
+              memory: '100Mi'
+            }
+          },
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }
@@ -103,6 +115,12 @@ module.exports.podWithFixHostname = (
         {
           name: containername,
           image: containerimage,
+          resources: {
+            limits: {
+              cpu: '200m',
+              memory: '100Mi'
+            }
+          },
           command: ['/bin/sh'],
           args: ['-c', "echo 'hello'; sleep 6000000"]
         }


### PR DESCRIPTION
# Add handling of missing jq dependency
- We do require `jq` to function, document and check for it.

# Use KaaS server address from config file (if given)
- It is obsolete to give a config file (`-c`), which **has the KaaS server address already in it** and then also provide it (again) on the command line via the `-s` option. Just pick it from the config file.

# Upgrade Alpine
- The Alpine docker 3.9 is quite old, upgrade to 3.18.
- NOTE! Commit force pushed, as @petedyerarm noticed a few more places where we used the old one.

# Trap errors with cleanup
- New cleanup function that traps errors to cleanup credentials/config -files.
